### PR TITLE
Plasmaman quality of life changes

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -49,6 +49,7 @@
 #define ALIEN_SELECT_AFK_BUFFER 1 // How many minutes that a person can be AFK before not being allowed to be an alien.
 #define SHOES_SLOWDOWN -1.0			// How much shoes slow you down by default. Negative values speed you up
 
+#define OXYCONCEN_PLASMEN_IGNITION 0.5 //Moles of oxygen in the air needed to light up a poorly clothed Plasmaman. Same as LINDA requirements for plasma burning.
 
 ////////REAGENT STUFF////////
 // How many units of reagent are consumed per tick, by default.

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -18,11 +18,8 @@
 
 	var/next_extinguish = 0
 	var/extinguish_cooldown = 10 SECONDS
-	var/extinguishes_left = 10 // Yeah yeah, reagents, blah blah blah.  This should be simple.
-
-/obj/item/clothing/suit/space/eva/plasmaman/examine(mob/user)
-	..(user)
-	to_chat(user, "<span class='info'>There are [extinguishes_left] extinguisher canisters left in this suit.</span>")
+	var/extinguishes_left = 5 // Yeah yeah, reagents, blah blah blah.  This should be simple.
+	var/max_extinguishes = 5
 
 /obj/item/clothing/suit/space/eva/plasmaman/proc/Extinguish(var/mob/user)
 	var/mob/living/carbon/human/H=user
@@ -32,8 +29,39 @@
 
 		next_extinguish = world.time + extinguish_cooldown
 		extinguishes_left--
-		to_chat(H, "<span class='warning'>Your suit automatically extinguishes the fire.</span>")
+		to_chat(user, "<span class='warning'>You hear a soft click and a hiss from your suit as it automatically extinguishes the fire.</span>")
+		if(!extinguishes_left)
+			to_chat(user, "<span class='warning'>Onboard auto-extinguisher depleted, refill with a cartridge.</span>")
+		playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)
 		H.ExtinguishMob()
+		
+/obj/item/clothing/suit/space/eva/plasmaman/attackby(var/obj/item/A as obj, mob/user as mob, params)
+	..()
+	if(istype(A, /obj/item/weapon/plasmensuit_cartridge)) //This suit can only be reloaded by the appropriate cartridges, and only if it's got no more extinguishes left.
+		if(!extinguishes_left)
+			extinguishes_left = max_extinguishes //Full replenishment from the cartridge.
+			to_chat(user, "<span class='notice'>You replenish \the [src] with the cartridge.</span>")
+			qdel(A)
+		else
+			to_chat(user, "<span class='notice'>The suit must be depleted before it can be refilled.</span>")
+			
+/obj/item/clothing/suit/space/eva/plasmaman/examine(mob/user)
+	..(user)
+	to_chat(user, "<span class='info'>There are [extinguishes_left] extinguisher charges left in this suit.</span>")
+
+/obj/item/weapon/plasmensuit_cartridge //Can be used to refill Plasmaman suits when they run out of autoextinguishes.
+	name = "auto-extinguisher cartridge"
+	desc = "A tiny and light fibreglass-framed auto-extinguisher cartridge."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "miniFE0"
+	item_state = "miniFE"
+	hitsound = null //Ultralight and
+	flags = null //non-conductive
+	force = 0
+	throwforce = 0
+	w_class = 1 //Fits in boxes.
+	materials = list()
+	attack_verb = list("tapped")
 
 /obj/item/clothing/head/helmet/space/eva/plasmaman
 	name = "plasmaman helmet"
@@ -90,7 +118,7 @@
 	base_state = "plasmamanAtmos_helmet"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 0)
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
-
+	flash_protect = 2
 /obj/item/clothing/suit/space/eva/plasmaman/engineer
 	name = "plasmaman engineer suit"
 	icon_state = "plasmamanEngineer_suit"
@@ -101,7 +129,7 @@
 	icon_state = "plasmamanEngineer_helmet0"
 	base_state = "plasmamanEngineer_helmet"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
-
+	flash_protect = 2
 /obj/item/clothing/suit/space/eva/plasmaman/engineer/ce
 	name = "plasmaman chief engineer suit"
 	icon_state = "plasmaman_CE"
@@ -112,7 +140,7 @@
 	icon_state = "plasmaman_CE_helmet0"
 	base_state = "plasmaman_CE_helmet"
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
-
+	flash_protect = 2
 
 //SERVICE
 

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -15,6 +15,7 @@
 	butt_sprite = "plasma"
 
 	breath_type = "plasma"
+	poison_type = null 
 
 	heat_level_1 = 350  // Heat damage level 1 above this point.
 	heat_level_2 = 400  // Heat damage level 2 above this point.
@@ -123,6 +124,8 @@
 	H.equip_or_collect(new suit(H), slot_wear_suit)
 	H.equip_or_collect(new helm(H), slot_head)
 	H.equip_or_collect(new/obj/item/weapon/tank/plasma/plasmaman(H), tank_slot) // Bigger plasma tank from Raggy.
+	H.equip_or_collect(new /obj/item/weapon/plasmensuit_cartridge(H), slot_in_backpack)
+	H.equip_or_collect(new /obj/item/weapon/plasmensuit_cartridge(H), slot_in_backpack)
 	to_chat(H, "<span class='notice'>You are now running on plasma internals from the [H.s_store] in your [tank_slot_name].  You must breathe plasma in order to survive, and are extremely flammable.</span>")
 	H.internal = H.get_item_by_slot(tank_slot)
 	H.update_internals_hud_icon(1)
@@ -155,13 +158,14 @@
 		else
 			H.adjustOxyLoss(HUMAN_MAX_OXYLOSS)
 			H.failed_last_breath = 1
-		H.oxygen_alert = max(H.oxygen_alert, 1)
+		H.throw_alert("tox_in_air", /obj/screen/alert/not_enough_tox)
 
 	else								// We're in safe limits
+		H.clear_alert("oxy") //For some reason this pops up when in deep crit then never goes away.
+		H.clear_alert("tox_in_air")
 		H.failed_last_breath = 0
 		H.adjustOxyLoss(-5)
 		plasma_used = breath.toxins/6
-		H.oxygen_alert = 0
 
 	breath.toxins -= plasma_used
 	breath.nitrogen -= nitrogen_used
@@ -231,9 +235,27 @@
 				H.apply_damage(HEAT_GAS_DAMAGE_LEVEL_3, BURN, "head", used_weapon = "Excessive Heat")
 				H.fire_alert = max(H.fire_alert, 2)
 
+/datum/species/plasmaman/handle_life(var/mob/living/carbon/human/H)
 	if(!istype(H.wear_suit, /obj/item/clothing/suit/space/eva/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/eva/plasmaman))
-		to_chat(H, "<span class='warning'>Your body reacts with the atmosphere and bursts into flame!</span>")
-		H.adjust_fire_stacks(0.5)
-		H.IgniteMob()
+		var/datum/gas_mixture/environment = H.loc.return_air()
+		if(environment && environment.oxygen && environment.oxygen >= OXYCONCEN_PLASMEN_IGNITION) //Plasmamen so long as there's enough oxygen (0.5 moles, same as it takes to burn gaseous plasma).
+			H.adjust_fire_stacks(0.5)
+			if(!H.on_fire && H.fire_stacks > 0)
+				H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
+			H.IgniteMob()
+	else
+		if(H.on_fire && H.fire_stacks > 0)
+			var/obj/item/clothing/suit/space/eva/plasmaman/P = H.wear_suit
+			if(istype(P))
+				P.Extinguish(H)
+	H.update_fire()
 
-	return 1
+/datum/species/plasmaman/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+	if(R.id == "plasma")
+		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustPlasma(20)
+		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
+		return 0 //Handling reagent removal on our own. Prevents plasma from dealing toxin damage to Plasmamen.
+
+	return ..()

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -251,7 +251,7 @@
 	H.update_fire()
 
 /datum/species/plasmaman/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
-	if(R.id == "plasma")
+	if(R.id == "plasma" || R.id == "plasma_dust")
 		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.adjustPlasma(20)


### PR DESCRIPTION
Thanks KasparoVy for the basis of this from normal paracode.

- Plasmamen will only burn if there's a certain amount of oxygen in the air (currently the same amount normal plasma takes to burn)

- Changes the HUD to show you when you don't have enough plasma rather than running out of oxygen

- Changed how the plasmaman suit autoextinguisher worked to a cartridge based system

- Added said autoextinguisher. Right now plasmamen start with two, with no current way to get more.

- Added welding protection to the engineering, atmospherics, and CE suits

- Changed atmospheric suit to have the same heat protection as the hardsuit

- Added the ability for plasmamen to heal by consuming plasma or plasma dust. Healing via other ways is still a lot faster.
I tested this a bunch, and it looks like everything works, and nothing breaks. Still no idea if I'm doing this right but hey, it's a start.