### PR TITLE
Add welding google to autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -760,3 +760,11 @@
 	materials = list(MAT_GLASS = 750, MAT_METAL = 250)
 	build_path = /obj/item/weapon/circuitboard/vendor
 	category = list("initial", "Electronics")
+
+/datum/design/welding_googles
+	name = "Welding Googles"
+	id = "welding_googles"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 750, MAT_GLASS = 300)
+	build_path = /obj/item/clothing/glasses/welding
+	category = list("initial","Construction")


### PR DESCRIPTION
**Why?**
Saw a list of uncraftables item and i took the easiest one i could find cuz first contribution 

**What does it do?**
This PR add de Welding Googles to the Autolathe. The materials to make it make it cheaper than the Welding Mask cause they are smaller i guess, could change it tho.
